### PR TITLE
identification until combined app+platform done

### DIFF
--- a/rust-common/src/lib.rs
+++ b/rust-common/src/lib.rs
@@ -2,9 +2,11 @@ use idesyde_core::{decision_models_schemas_gen, RustEmbeddedModule};
 use models::{
     AnalysedSDFApplication, AperiodicAsynchronousDataflow,
     AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticore,
+    AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticoreAndPL,
     AperiodicAsynchronousDataflowToPartitionedTiledMulticore, InstrumentedComputationTimes,
-    InstrumentedMemoryRequirements, MemoryMappableMultiCore, PartitionedMemoryMappableMulticore,
-    PartitionedTiledMulticore, RuntimesAndProcessors, SDFApplication, TiledMultiCore,
+    InstrumentedMemoryRequirements, MemoryMappableMultiCore, MM_MCoreAndPL,
+    PartitionedMemoryMappableMulticore, PartitionedMemoryMappableMulticoreAndPL, TiledMultiCore, 
+    PartitionedTiledMulticore, RuntimesAndProcessors, SDFApplication,
 };
 use schemars::schema_for;
 use std::{collections::HashSet, sync::Arc};
@@ -29,7 +31,13 @@ pub fn make_module() -> RustEmbeddedModule {
             irules::identify_partitioned_mem_mapped_multicore,
         )),
         Arc::new(idesyde_core::MarkedIdentificationRule::DecisionModelOnlyIdentificationRule(
+            irules::identify_partitioned_mem_mapped_multicore_and_pl,
+        )),
+        Arc::new(idesyde_core::MarkedIdentificationRule::DecisionModelOnlyIdentificationRule(
             irules::identify_aperiodic_asynchronous_dataflow_to_partitioned_mem_mappable_multicore,
+        )),
+        Arc::new(idesyde_core::MarkedIdentificationRule::DecisionModelOnlyIdentificationRule(
+            irules::identify_aperiodic_asynchronous_dataflow_to_partitioned_mem_mappable_multicore_and_pl,
         )),
         Arc::new(idesyde_core::MarkedIdentificationRule::DecisionModelOnlyIdentificationRule(
             irules::identify_analyzed_sdf_from_common_sdf,
@@ -60,8 +68,11 @@ pub fn make_module() -> RustEmbeddedModule {
             InstrumentedMemoryRequirements,
             AperiodicAsynchronousDataflowToPartitionedTiledMulticore,
             MemoryMappableMultiCore,
+            MM_MCoreAndPL,
             PartitionedMemoryMappableMulticore,
-            AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticore
+            PartitionedMemoryMappableMulticoreAndPL,
+            AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticore,
+            AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticoreAndPL
         ])
         .build()
         .expect("Failed to build common standalone identification module. Should never happen.")

--- a/rust-common/src/models.rs
+++ b/rust-common/src/models.rs
@@ -266,6 +266,48 @@ impl DecisionModel for MemoryMappableMultiCore {
     }
 }
 
+/// A decision model capturing the memory mappable platform abstraction.
+///
+/// This type of platform is what one would expect from most COTS platforms
+/// and hardware designs, which completely or partially follows a von neumman
+/// architecture. This means that the storage elements store both data and instructions
+/// and the processors access them going through the communication elements; the latter
+/// that form the 'interconnect'. In addition to standard software processing elements,
+/// this decision model also includes programmable logic capacities on the platform.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, JsonSchema)]
+pub struct MM_MCoreAndPL {
+    pub processing_elems: HashSet<String>,
+    pub pl_module_available_areas: HashMap<String, u32>,
+    pub storage_elems: HashSet<String>,
+    pub communication_elems: HashSet<String>,
+    pub topology_srcs: Vec<String>,
+    pub topology_dsts: Vec<String>,
+    pub processors_frequency: HashMap<String, u64>,
+    pub processors_provisions: HashMap<String, HashMap<String, HashMap<String, f64>>>,
+    pub storage_sizes: HashMap<String, u64>,
+    pub communication_elements_max_channels: HashMap<String, u32>,
+    pub communication_elements_bit_per_sec_per_channel: HashMap<String, f64>,
+    pub pre_computed_paths: HashMap<String, HashMap<String, Vec<String>>>,
+}
+
+impl DecisionModel for MM_MCoreAndPL {
+    impl_decision_model_standard_parts!(MM_MCoreAndPL);
+
+    fn part(&self) -> HashSet<String> {
+        let mut elems: HashSet<String> = HashSet::new();
+        elems.extend(self.processing_elems.iter().map(|x: &String| x.to_owned()));
+        elems.extend(self.storage_elems.iter().map(|x: &String| x.to_owned()));
+        elems.extend(self.communication_elems.iter().map(|x: &String| x.to_owned()));
+        for i in 0..self.topology_dsts.len() {
+            elems.insert(format!(
+                "{}:{}-{}:{}",
+                self.topology_srcs[i], "", self.topology_dsts[i], ""
+            ));
+        }
+        elems
+    }
+}
+
 /// A decision model capturing the binding between procesing element and runtimes.
 ///
 /// A runtime here is used in a loose sense: it can be simply a programmable bare-metal
@@ -338,6 +380,28 @@ pub struct PartitionedMemoryMappableMulticore {
 
 impl DecisionModel for PartitionedMemoryMappableMulticore {
     impl_decision_model_standard_parts!(PartitionedMemoryMappableMulticore);
+
+    fn part(&self) -> HashSet<String> {
+        let mut elems: HashSet<String> = HashSet::new();
+        elems.extend(self.hardware.part().iter().map(|x| x.to_owned()));
+        elems.extend(self.runtimes.part().iter().map(|x| x.to_owned()));
+        elems
+    }
+}
+
+/// A decision model that captures a paritioned-scheduled memory mappable multicore machine
+///
+/// This means that every processing element hosts and has affinity for one and only one runtime element.
+/// This runtime element can execute according to any scheduling policy, but it must control only
+/// its host.
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct PartitionedMemoryMappableMulticoreAndPL {
+    pub hardware: MM_MCoreAndPL,
+    pub runtimes: RuntimesAndProcessors,
+}
+
+impl DecisionModel for PartitionedMemoryMappableMulticoreAndPL {
+    impl_decision_model_standard_parts!(PartitionedMemoryMappableMulticoreAndPL);
 
     fn part(&self) -> HashSet<String> {
         let mut elems: HashSet<String> = HashSet::new();
@@ -533,6 +597,75 @@ pub struct AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticore {
 impl DecisionModel for AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticore {
     impl_decision_model_standard_parts!(
         AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticore
+    );
+
+    fn part(&self) -> HashSet<String> {
+        let mut elems: HashSet<String> = HashSet::new();
+        for app in &self.aperiodic_asynchronous_dataflows {
+            elems.extend(app.part().iter().map(|x| x.to_owned()));
+        }
+        elems.extend(
+            self.partitioned_mem_mappable_multicore
+                .part()
+                .iter()
+                .map(|x| x.to_owned()),
+        );
+        elems.extend(
+            self.instrumented_computation_times
+                .part()
+                .iter()
+                .map(|x| x.to_owned()),
+        );
+        elems.extend(
+            self.instrumented_memory_requirements
+                .part()
+                .iter()
+                .map(|x| x.to_owned()),
+        );
+        for (pe, sched) in &self.processes_to_runtime_scheduling {
+            elems.insert(format!("{}={}:{}-{}:{}", "scheduling", pe, "", sched, ""));
+        }
+        for (pe, mem) in &self.processes_to_memory_mapping {
+            elems.insert(format!("{}={}:{}-{}:{}", "mapping", pe, "", mem, ""));
+        }
+        for (buf, mem) in &self.buffer_to_memory_mappings {
+            elems.insert(format!("{}={}:{}-{}:{}", "mapping", buf, "", mem, ""));
+        }
+        for (pe, ce_slots) in &self.processing_elements_to_routers_reservations {
+            for (ce, slots) in ce_slots {
+                if *slots > 0 {
+                    elems.insert(format!("{}={}:{}-{}:{}", "reservation", pe, "", ce, ""));
+                }
+            }
+        }
+        elems
+    }
+}
+
+/// A decision model that combines aperiodic dataflows to partitioned memory mappable platforms with
+/// both software and hardware processing elements.
+///
+/// The assumptions of this decision model are:
+///  1. For every process, there is at least one processing element in the platform that can run it.
+///     Otherwise, even the trivial mapping is impossible.
+///  2. Super loop schedules are self-timed and stall the processing element that is hosting them.
+///     That is, if we have a poor schedule, the processing element will get "blocked" often.
+#[derive(Debug, PartialEq, Serialize, Deserialize, Clone, JsonSchema)]
+pub struct AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticoreAndPL {
+    pub aperiodic_asynchronous_dataflows: Vec<AperiodicAsynchronousDataflow>,
+    pub partitioned_mem_mappable_multicore: PartitionedMemoryMappableMulticoreAndPL,
+    pub instrumented_computation_times: InstrumentedComputationTimes,
+    pub instrumented_memory_requirements: InstrumentedMemoryRequirements,
+    pub processes_to_runtime_scheduling: HashMap<String, String>,
+    pub processes_to_memory_mapping: HashMap<String, String>,
+    pub buffer_to_memory_mappings: HashMap<String, String>,
+    pub super_loop_schedules: HashMap<String, Vec<String>>,
+    pub processing_elements_to_routers_reservations: HashMap<String, HashMap<String, u16>>,
+}
+
+impl DecisionModel for AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticoreAndPL {
+    impl_decision_model_standard_parts!(
+        AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticoreAndPL
     );
 
     fn part(&self) -> HashSet<String> {


### PR DESCRIPTION
Adds three decision models in the rust-common module:
- `MM_MCoreAndPL`
- `PartitionedMemoryMappableMulticoreAndPL`
- `AperiodicAsynchronousDataflowToPartitionedMemoryMappableMulticoreAndPL`

No new fields have been added, it's still just the area property that follows along as the decision models are combined.

Now that all identification is done, it became quite apparent that a lot of code is heavily duplicated to solely accommodate for different naming (since the actual **new** stuff is at the lowest level of identification in MemoryMappedMultiCoreAndPL). Not sure what the solution would be though and of course this is not an issue nor something that I have to do for my thesis.

_Note_: sorry about the decision model naming that breaks the naming pattern. I didn't think it through beforehand but it looks a little ugly now in the context of all other decision models.