### PR TITLE
adds hw impl area irule for instrhwbehavior

### DIFF
--- a/java-bridge-forsyde-io/src/main/java/idesyde/forsydeio/HardwareImplementationAreasIRule.java
+++ b/java-bridge-forsyde-io/src/main/java/idesyde/forsydeio/HardwareImplementationAreasIRule.java
@@ -1,0 +1,55 @@
+package idesyde.forsydeio;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Set;
+
+import forsyde.io.core.SystemGraph;
+import idesyde.common.HardwareImplementationArea;
+import idesyde.core.*;
+import forsyde.io.lib.hierarchy.ForSyDeHierarchy.*;
+
+@AutoRegister(ForSyDeIOModule.class)
+class HardwareImplementationAreasIRule implements IdentificationRule {
+    @Override
+    public IdentificationResult apply(
+        Set<? extends DesignModel> designModels,
+        Set<? extends DecisionModel> decisionModels
+    ) {
+        var requiredAreas = new HashMap<String, Long>();
+        var errors = new HashSet<String>();
+        var model = new SystemGraph();
+        for (var dm : designModels) {
+            ForSyDeIODesignModel.tryFrom(dm)
+                .map(ForSyDeIODesignModel::systemGraph)
+                .ifPresent(model::mergeInPlace);
+        }
+
+        model.vertexSet().stream().forEach(v ->
+            InstrumentedHardwareBehaviour
+                .tryView(model, v)
+                .ifPresent(hw -> {
+                    long area = hw.requiredHardwareImplementationArea();
+                    if (area > 0) {
+                        requiredAreas.put(hw.getIdentifier(), area);
+                    } else {
+                        errors.add(
+                            "HardwareImplementationAreasIRule: Could not " +
+                            "identify hardware implementation area, or <= 0 for " + 
+                            hw.getIdentifier()
+                        );
+                    } 
+                })
+        );
+
+        if (requiredAreas.isEmpty()) {
+            errors.add(
+                "Error: No implementations of actors in hardware identified"
+            );
+        }
+
+        return new IdentificationResult(
+            Set.of(new HardwareImplementationArea(requiredAreas)), errors
+        );
+    }
+}

--- a/java-common/src/main/java/idesyde/common/HardwareImplementationArea.java
+++ b/java-common/src/main/java/idesyde/common/HardwareImplementationArea.java
@@ -1,0 +1,21 @@
+package idesyde.common;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import idesyde.core.DecisionModel;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+/**
+ * A decision model to hold the required area that a hardware implementation needs.
+ */
+public record HardwareImplementationArea(
+        @JsonProperty("required_areas") Map<String, Long> requiredAreas
+) implements DecisionModel {
+    @Override
+    public Set<String> part() {
+        return Set.of();
+    }
+}


### PR DESCRIPTION
Adds a new identification rule and the corresponding decision model to capture the area required by an actor (InstrumentedHardwareBehavior).

Question:
`part()` just returns the empty set, is that ok?